### PR TITLE
add engine 打补丁机制

### DIFF
--- a/lib/kc_courses/engine.rb
+++ b/lib/kc_courses/engine.rb
@@ -4,6 +4,10 @@ module KcCourses
     config.to_prepare do
       ApplicationController.helper ::ApplicationHelper
 
+      Dir.glob(Rails.root + "app/decorators/kc_courses/**/*_decorator.rb").each do |c|
+        require_dependency(c)
+      end
+
       User.class_eval do
         has_many :courses, class_name: 'KcCourses::Course'
         has_many :chapters, class_name: 'KcCourses::Chapter'


### PR DESCRIPTION
以前给 gem/engine 打补丁都是写在 `config/initializers/gem_integration.rb` 一个文件，当 gem/engine 过多时，便不再好维护了

所以想出这个方便维护的方式:  
集成时，把补丁文件按照 `xxx_decorator.rb` 来命名，并放到 `app/decorators/<gem_name>` 目录
